### PR TITLE
Add subtitle for 2018 to banner, title etc

### DIFF
--- a/imprint.html
+++ b/imprint.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 
-	<title>HackHPI 2017 - Health Tech Hackathon</title>
+	<title>HackHPI 2018 - about://environment Hackathon</title>
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
@@ -42,7 +42,7 @@
 			<div class="row">
 				<div class="col-md-8 col-md-offset-2 text-center">
 					<a href="/" class="logo"></a>
-					<span class="title">Health Tech Hackathon</span>
+					<span class="title">about://environment</span>
 					<span class="subtitle">17 - 18 June 2017<br>Hasso Plattner Institute (close to Berlin)</span>
 				</div>
 			</div>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
 
-	<title>HackHPI 2018 - Health Tech Hackathon</title>
+	<title>HackHPI 2018 - about://environment Hackathon</title>
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
@@ -13,7 +13,6 @@
 	<link rel="stylesheet" type="text/css" href="./hackhpi_assets/style.css">
 
 	<link rel="icon" type="image/png" href="./hackhpi_assets/favicon.png">
-	<title>HackHPI - HackHPI 2018 - Health Tech Hackathon</title>
 	<meta name="keywords" content="">
 	<meta name="description" content="Wearables, data and lots of caffeine - come join our Health Tech Hackathon on 17th and 18th of June 2017 at Hasso Plattner Institute.">
 	<meta name="image" content="http://hackhpi.org/site/templates/images/facebook-preview.png">
@@ -21,14 +20,14 @@
 	<meta name="generator" content="ProcessWire 3.0.15">
 	<meta name="author" content="HackHPI">
 	<meta property="og:site_name" content="HackHPI">
-	<meta property="og:title" content="HackHPI 2018 - Health Tech Hackathon">
+	<meta property="og:title" content="HackHPI 2018 - about://environment Hackathon">
 	<meta property="og:url" content="https://hackhpi.org/">
 	<meta property="og:description" content="Wearables, data and lots of caffeine - come join our Health Tech Hackathon on 17th and 18th of June 2017 at Hasso Plattner Institute.">
 	<meta property="og:type" content="website">
 	<meta property="og:image" content="http://hackhpi.org/site/templates/images/facebook-preview.png">
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:site" content="@HackHPI">
-	<meta name="twitter:title" content="HackHPI 2018 - Health Tech Hackathon">
+	<meta name="twitter:title" content="HackHPI 2018 - about://environment Hackathon">
 	<meta name="twitter:url" content="https://hackhpi.org/">
 	<meta name="twitter:description" content="Wearables, data and lots of caffeine - come join our Health Tech Hackathon on 17th and 18th of June 2017 at Hasso Plattner Institute.">
 	<meta name="twitter:image" content="http://hackhpi.org/site/templates/images/facebook-preview.png">
@@ -61,7 +60,7 @@
 			<div class="row">
 				<div class="col-md-8 col-md-offset-2 text-center">
 					<a href="#" class="logo"></a>
-					<span class="title">Green Tech Hackathon</span>
+					<span class="title">about://environment</span>
 					<span class="subtitle">tbd May|June|July 2018<br>Hasso Plattner Institute (close to Berlin)</span>
 				</div>
 			</div>

--- a/press.html
+++ b/press.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 
-	<title>HackHPI 2017 - Health Tech Hackathon</title>
+	<title>HackHPI 2018 - about://environment Hackathon</title>
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
@@ -42,7 +42,7 @@
 			<div class="row">
 				<div class="col-md-8 col-md-offset-2 text-center">
 					<a href="/" class="logo"></a>
-					<span class="title">Health Tech Hackathon</span>
+					<span class="title">about://environment</span>
 					<span class="subtitle">17 - 18 June 2017<br>Hasso Plattner Institute (close to Berlin)</span>
 				</div>
 			</div>

--- a/sponsor-information.html
+++ b/sponsor-information.html
@@ -3,7 +3,7 @@
 <html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	
 
-	<title>HackHPI 2018 - Health Tech Hackathon</title>
+	<title>HackHPI 2018 - about://environment Hackathon</title>
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
@@ -46,7 +46,7 @@
 
 					<!--<div id="countdown"></div>-->
 
-					<span class="title">Green Tech Hackathon</span>
+					<span class="title">about://environment</span>
 					<span class="subtitle">tbd May|June|July 2018<br>Hasso Plattner Institute (close to Berlin)</span>
 				</div>
 			</div>


### PR DESCRIPTION
Closes #35.
In the `meta` and `title` tags, I put "about://environment **Hackathon**" instead of just "about://environment" so that people can find the right tab easier again among their thousands of browser tabs. ;) Also SEO!?