### PR TITLE
Added vimeo facade on load

### DIFF
--- a/src/components/WhatToExpect/WhatToExpect.jsx
+++ b/src/components/WhatToExpect/WhatToExpect.jsx
@@ -1,8 +1,13 @@
-import {Box, Container, Grid, Typography} from "@mui/material";
+"use client"
+import {Box, Container, Grid, IconButton, Typography} from "@mui/material";
 import {WindowCard} from "../WindowCard/WindowCard.jsx";
 import HackHPIWrapper from "../Theme/HackHPIWrapper.jsx";
+import {PlayArrow} from "@mui/icons-material";
+import {useState} from "react";
 
 function WhatToExpect() {
+
+    const [playVideo, setPlayVideo] = useState(false)
 
     return (
         <HackHPIWrapper>
@@ -28,13 +33,34 @@ function WhatToExpect() {
                     <Grid item xs={12} md={4} sx={{display: "flex", justifyContent: "center"}}>
                         <Box sx={{width: "100%"}}>
                             <WindowCard>
-                                <iframe
-                                    src="https://player.vimeo.com/video/867922224?h=30cf0b8b55&title=0&byline=0&portrait=0"
-                                    style={{aspectRatio: "16 / 9", borderRadius: "5px", width: "100%"}}
-                                    allow="autoPlay; fullscreen; picture-in-picture"
-                                    allowFullScreen
-                                    title={"Image Movie"}
-                                />
+                                {playVideo ? (
+                                    <iframe
+                                        src="https://player.vimeo.com/video/867922224?h=30cf0b8b55&title=0&byline=0&portrait=0&autoplay=1&muted=1"
+                                        style={{aspectRatio: "16 / 9", borderRadius: "5px", width: "100%", border: 0}}
+                                        allow="autoPlay; fullscreen; picture-in-picture"
+                                        allowFullScreen
+                                        title={"Image Movie"}
+                                    />
+                                ) : (
+                                    <Box
+                                        style={{
+                                            aspectRatio: "16 / 9",
+                                            borderRadius: "5px",
+                                            width: "100%",
+                                            background: `linear-gradient(rgba(0,0,0,.5), rgba(0,0,0,.5)), url(https://vumbnail.com/867922224.jpg)`,
+                                            backgroundRepeat: "no-repeat",
+                                            backgroundSize: "cover",
+                                            display: "flex",
+                                            alignItems: "center",
+                                            justifyContent: "center",
+                                        }}
+                                    >
+                                        <IconButton onClick={() => setPlayVideo(true)}>
+                                            <PlayArrow sx={{fontSize: "3rem"}}/>
+                                        </IconButton>
+                                    </Box>
+                                )}
+
                             </WindowCard>
                         </Box>
                     </Grid>

--- a/src/components/WhatToExpect/WhatToExpect.jsx
+++ b/src/components/WhatToExpect/WhatToExpect.jsx
@@ -8,6 +8,7 @@ import {useState} from "react";
 function WhatToExpect() {
 
     const [playVideo, setPlayVideo] = useState(false)
+    const vimeoVideoId = "867922224"
 
     return (
         <HackHPIWrapper>
@@ -35,7 +36,7 @@ function WhatToExpect() {
                             <WindowCard>
                                 {playVideo ? (
                                     <iframe
-                                        src="https://player.vimeo.com/video/867922224?h=30cf0b8b55&title=0&byline=0&portrait=0&autoplay=1&muted=1"
+                                        src={`https://player.vimeo.com/video/${vimeoVideoId}?h=30cf0b8b55&title=0&byline=0&portrait=0&autoplay=1&muted=1`}
                                         style={{aspectRatio: "16 / 9", borderRadius: "5px", width: "100%", border: 0}}
                                         allow="autoPlay; fullscreen; picture-in-picture"
                                         allowFullScreen
@@ -47,7 +48,7 @@ function WhatToExpect() {
                                             aspectRatio: "16 / 9",
                                             borderRadius: "5px",
                                             width: "100%",
-                                            background: `linear-gradient(rgba(0,0,0,.5), rgba(0,0,0,.5)), url(https://vumbnail.com/867922224.jpg)`,
+                                            background: `linear-gradient(rgba(0,0,0,.5), rgba(0,0,0,.5)), url(https://vumbnail.com/${vimeoVideoId}.jpg)`,
                                             backgroundRepeat: "no-repeat",
                                             backgroundSize: "cover",
                                             display: "flex",


### PR DESCRIPTION
External sources add loading time (and trackers to the side). Therefore the iframe will be loaded when clicking on it.

See https://developer.chrome.com/docs/lighthouse/performance/third-party-facades/?utm_source=lighthouse&utm_medium=lr for more information 